### PR TITLE
Add Renault Zoe ZE50 OBD signal mappings

### DIFF
--- a/signalsets/v3/2019-2024.json
+++ b/signalsets/v3/2019-2024.json
@@ -1,0 +1,208 @@
+{
+  "diagnosticLevel": "03",
+  "commands": [
+    {
+      "hdr": "DADA",
+      "rax": "DAF1DA",
+      "proto": "15765-4-29bit",
+      "cmd": {
+        "22": "2003"
+      },
+      "freq": 1,
+      "signals": [
+        {
+          "id": "RENAULT_ZOE_VEHICLE_REPORTED_SPEED",
+          "path": "Movement",
+          "fmt": {
+            "len": 16,
+            "div": 100,
+            "min": 0,
+            "max": 180,
+            "unit": "kilometersPerHour"
+          },
+          "name": "Vehicle reported speed",
+          "suggestedMetric": "speed"
+        }
+      ],
+      "pri": "18",
+      "tst": "F1"
+    },
+    {
+      "hdr": "DADA",
+      "rax": "DAF1DA",
+      "proto": "15765-4-29bit",
+      "cmd": {
+        "22": "20FE"
+      },
+      "freq": 1,
+      "signals": [
+        {
+          "id": "RENAULT_ZOE_HVBAT_VOLTAGE",
+          "path": "Battery",
+          "fmt": {
+            "len": 16,
+            "div": 10,
+            "min": 300,
+            "max": 480,
+            "unit": "volts"
+          },
+          "name": "HV battery voltage"
+        }
+      ],
+      "pri": "18",
+      "tst": "F1"
+    },
+    {
+      "hdr": "DADA",
+      "rax": "DAF1DA",
+      "proto": "15765-4-29bit",
+      "cmd": {
+        "22": "21CC"
+      },
+      "freq": 1,
+      "signals": [
+        {
+          "id": "RENAULT_ZOE_HVBAT_CURRENT",
+          "path": "Battery",
+          "fmt": {
+            "len": 16,
+            "mul": -0.25,
+            "add": 500,
+            "min": -2000,
+            "max": 2000,
+            "unit": "amps"
+          },
+          "name": "HV battery current"
+        }
+      ],
+      "pri": "18",
+      "tst": "F1"
+    },
+    {
+      "hdr": "DADA",
+      "rax": "DAF1DA",
+      "proto": "15765-4-29bit",
+      "cmd": {
+        "22": "2006"
+      },
+      "freq": 5,
+      "signals": [
+        {
+          "id": "RENAULT_ZOE_ODOMETER",
+          "path": "Trips",
+          "fmt": {
+            "len": 24,
+            "min": 0,
+            "max": 500000,
+            "unit": "kilometers"
+          },
+          "name": "Odometer"
+        }
+      ],
+      "pri": "18",
+      "tst": "F1"
+    },
+    {
+      "hdr": "DADB",
+      "rax": "DAF1DB",
+      "proto": "15765-4-29bit",
+      "cmd": {
+        "22": "9001"
+      },
+      "freq": 1,
+      "signals": [
+        {
+          "id": "RENAULT_ZOE_SOC_BMS",
+          "path": "Battery",
+          "fmt": {
+            "len": 16,
+            "div": 100,
+            "min": 0,
+            "max": 105,
+            "unit": "percent"
+          },
+          "name": "BMS state of charge",
+          "suggestedMetric": "stateOfCharge"
+        }
+      ],
+      "pri": "18",
+      "tst": "F1"
+    },
+    {
+      "hdr": "DADB",
+      "rax": "DAF1DB",
+      "proto": "15765-4-29bit",
+      "cmd": {
+        "22": "9003"
+      },
+      "freq": 30,
+      "signals": [
+        {
+          "id": "RENAULT_ZOE_SOH",
+          "path": "Battery",
+          "fmt": {
+            "len": 16,
+            "div": 100,
+            "min": 50,
+            "max": 105,
+            "unit": "percent"
+          },
+          "name": "Battery state of health"
+        }
+      ],
+      "pri": "18",
+      "tst": "F1"
+    },
+    {
+      "hdr": "DADB",
+      "rax": "DAF1DB",
+      "proto": "15765-4-29bit",
+      "cmd": {
+        "22": "9012"
+      },
+      "freq": 5,
+      "signals": [
+        {
+          "id": "RENAULT_ZOE_HVBAT_TEMP",
+          "path": "Battery",
+          "fmt": {
+            "len": 16,
+            "mul": 0.0625,
+            "add": -40,
+            "min": -40,
+            "max": 60,
+            "unit": "celsius"
+          },
+          "name": "HV battery temperature"
+        }
+      ],
+      "pri": "18",
+      "tst": "F1"
+    },
+    {
+      "hdr": "DADB",
+      "rax": "DAF1DB",
+      "proto": "15765-4-29bit",
+      "cmd": {
+        "22": "91C8"
+      },
+      "freq": 30,
+      "signals": [
+        {
+          "id": "RENAULT_ZOE_KWH_CHARGED",
+          "path": "Battery.Charging",
+          "fmt": {
+            "len": 24,
+            "div": 1000,
+            "min": 0,
+            "max": 60,
+            "unit": "kilowattHours"
+          },
+          "name": "Energy charged"
+        }
+      ],
+      "pri": "18",
+      "tst": "F1"
+    }
+  ]
+}


### PR DESCRIPTION
Adds initial OBD signal mappings for Renault Zoe ZE50 / 52 kWh vehicles.

Observed vehicle:
- Pelican vehicle: Zoe '20
- Typecode: renault:zoe:20:52:r110:noccs
- Scanner: iOS-Vlink / ELM327 v2.3

Reasoning:
- `signalsets/v3/default.json` was empty in the Renault-ZOE repo.
- Generic 11-bit PID detection over ECUs 7E0-7E7 returned 0 results for Service 22 range 0x2000-0x21FF.
- Pelican handshake succeeded with 29-bit VIN, UDS.
- These mappings are based on known ABRP/Pelican-style commands using protocol 7 / ATSP7, diagnostic session 1003, and 29-bit UDS headers.

Placement:
- Added to `signalsets/v3/2019-2024.json` to target ZE50-era Zoe vehicles rather than applying these commands to earlier Zoe variants through `default.json`.

Known command groups:
- `18DADAF1` / response `18DAF1DA`
- `18DADBF1` / response `18DAF1DB`

Known caveat:
- SOC PID `229002` is intentionally not included yet because the source configuration was ambiguous about whether it belongs under `DADAF1` or `DADBF1`.